### PR TITLE
Support drag-and-drop with touch

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "@types/react-dom": "^16.8.2",
     "@types/react-hot-loader": "^3.0.6",
     "@types/uuid": "^3.4.4",
-    "@types/webpack": "^3.0.13",
+    "@types/webpack": "^4.4.32",
     "chai": "^4.2.0",
     "css-loader": "^0.28.10",
     "file-loader": "^1.1.11",

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     "@types/mocha": "^2.2.48",
     "@types/prop-types": "^15.5.6",
     "@types/react": "^16.8.4",
+    "@types/react-dnd-multi-backend": "^3.0.5",
     "@types/react-dom": "^16.8.2",
     "@types/react-hot-loader": "^3.0.6",
     "@types/uuid": "^3.4.4",
@@ -80,6 +81,8 @@
     "prop-types": "^15.6.2",
     "react-dnd": "^5.0.0",
     "react-dnd-html5-backend": "^5.0.1",
+    "react-dnd-multi-backend": "^3.2.1",
+    "react-dnd-touch-backend": "^0.8.3",
     "uuid": "^3.3.2"
   },
   "peerDependencies": {

--- a/src/Mosaic.tsx
+++ b/src/Mosaic.tsx
@@ -4,7 +4,8 @@ import keys from 'lodash/keys';
 import pickBy from 'lodash/pickBy';
 import React from 'react';
 import { DragDropContext } from 'react-dnd';
-import HTML5 from 'react-dnd-html5-backend';
+import MultiBackend from 'react-dnd-multi-backend';
+import HTML5toTouch from 'react-dnd-multi-backend/lib/HTML5toTouch';
 import { v4 as uuid } from 'uuid';
 import { ModernMosaicContext, MosaicContext, MosaicRootActions } from './contextTypes';
 import { MosaicRoot } from './MosaicRoot';
@@ -205,7 +206,7 @@ export class MosaicWithoutDragDropContext<T extends MosaicKey = string> extends 
   }
 }
 
-@(DragDropContext(HTML5) as ClassDecorator)
+@(DragDropContext(MultiBackend(HTML5toTouch)) as ClassDecorator)
 export class Mosaic<T extends MosaicKey = string> extends MosaicWithoutDragDropContext<T> {
   static ofType<T extends MosaicKey>() {
     return Mosaic as new (props: MosaicProps<T>, context?: any) => Mosaic<T>;

--- a/src/MosaicWindow.tsx
+++ b/src/MosaicWindow.tsx
@@ -348,7 +348,7 @@ export class MosaicWindow<T extends MosaicKey = string> extends React.PureCompon
   }
 
   render() {
-    return <SourceDropConnectedInternalMosaicWindow {...this.props as InternalMosaicWindowProps<T>} />;
+    return <SourceDropConnectedInternalMosaicWindow {...(this.props as InternalMosaicWindowProps<T>)} />;
   }
 }
 


### PR DESCRIPTION
#### Changes proposed in this pull request:

Switch from `react-dnd-html5-backend` as the drag-and-drop backend to `react-dnd-multi-backend`, which supports touch events. `react-dnd-multi-backend` actually uses `react-dnd-html5-backend` until a touch event is observed, at which point it switches to `react-dnd-touch-backend`. Thus, this should have about identical behavior to normal for most users of `react-mosaic` whose clients will not send touch events. [More details on how that library works here.](https://github.com/LouisBrunner/dnd-multi-backend/tree/master/packages/react-dnd-multi-backend)

Also fixes two issues that were breaking `npm run test` / `npm run build`.

#### Reviewers should focus on:

Historical corner cases that have been problematic with drag-and-drop in the past? I've done comparative tests between touch and mouse and they appear to behave identically, but I'm not sure if there's a pathological case I should be checking.

#### Screenshot

![react-mosaic-touch](https://user-images.githubusercontent.com/1550614/59573243-dff5c280-9066-11e9-8243-0bdbc7fc3ce7.gif)
