### PR TITLE
Fix build errors in dependent projects

### DIFF
--- a/styles/blueprint-theme.less
+++ b/styles/blueprint-theme.less
@@ -1,4 +1,4 @@
-@import (reference) '../node_modules/@blueprintjs/core/lib/less/variables';
+@import (reference) '~@blueprintjs/core/lib/less/variables';
 
 .mosaic.mosaic-blueprint-theme {
   background: @gray4;


### PR DESCRIPTION
Relative paths in source files should definitely not reference directories outside this repository.
