### PR TITLE
Mark *.css as sideEffects required

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "lib/index.js",
   "style": "lib/react-mosaic.css",
   "typings": "lib/index.d.ts",
-  "sideEffects": false,
+  "sideEffects": ["*.css"],
   "repository": {
     "type": "git",
     "url": "https://github.com/nomcopter/react-mosaic.git"


### PR DESCRIPTION
#### Changes proposed in this pull request:

```js
import 'react-mosaic-component/react-mosaic-component.css';
```
Currently above css file is dropping from module bundlers (e.g. webpack) due to its sideEffect flags.
It works fine after change the `sideEffects` property. 

References:
https://github.com/webpack/webpack/issues/6741
https://github.com/webpack/webpack/issues/8814

