### PR TITLE
Add dragAndDropManager to the MosaicProps

### DIFF
--- a/README.md
+++ b/README.md
@@ -199,6 +199,10 @@ export interface MosaicBaseProps<T extends MosaicKey> {
    * default: Random UUID
    */
   mosaicId?: string;
+  /**
+   * Override the react-dnd provider to allow applications to inject an existing drag and drop context
+   */
+  dragAndDropManager?: DragDropManager | undefined;
 }
 
 export interface MosaicControlledProps<T extends MosaicKey> extends MosaicBaseProps<T> {

--- a/package.json
+++ b/package.json
@@ -48,6 +48,7 @@
     "@types/webpack": "^3.8.18",
     "chai": "^4.2.0",
     "css-loader": "^0.28.11",
+    "dnd-core": "^10.0.2",
     "file-loader": "^1.1.11",
     "html-loader": "^0.5.5",
     "html-webpack-plugin": "^2.30.1",

--- a/src/Mosaic.tsx
+++ b/src/Mosaic.tsx
@@ -1,4 +1,5 @@
 import classNames from 'classnames';
+import { DragDropManager } from 'dnd-core';
 import countBy from 'lodash/countBy';
 import keys from 'lodash/keys';
 import pickBy from 'lodash/pickBy';
@@ -52,6 +53,10 @@ export interface MosaicBaseProps<T extends MosaicKey> {
    * default: Random UUID
    */
   mosaicId?: string;
+  /**
+   * Override the react-dnd provider to allow applications to inject an existing drag and drop context
+   */
+  dragAndDropManager?: DragDropManager | undefined;
 }
 
 export interface MosaicControlledProps<T extends MosaicKey> extends MosaicBaseProps<T> {
@@ -209,7 +214,11 @@ export class MosaicWithoutDragDropContext<T extends MosaicKey = string> extends 
 export class Mosaic<T extends MosaicKey = string> extends React.PureComponent<MosaicProps<T>> {
   render() {
     return (
-      <DndProvider backend={MultiBackend} options={HTML5ToTouch}>
+      <DndProvider
+        backend={MultiBackend}
+        options={HTML5ToTouch}
+        {...(this.props.dragAndDropManager && { manager: this.props.dragAndDropManager })}
+      >
         <MosaicWithoutDragDropContext<T> {...this.props} />
       </DndProvider>
     );


### PR DESCRIPTION
#### Changes proposed in this pull request:

This should allow containing applications to provide an external react-dnd context. It seems like this may have been supported by previous react-dnd (#74), but we're seeing this crop up again in https://github.com/ProjectMirador/mirador/pull/3094 when we use react-dnd in our application.

```
HTML5Backend.js?56ae:380 Uncaught Error: Cannot have two HTML5 backends at the same time.
    at HTML5Backend.setup (HTML5Backend.js?56ae:380)
    at _default.setup (MultiBackend.js?7d82:75)
    at DragDropManagerImpl.handleRefCountChange (DragDropManagerImpl.js?e1b0:40)
    at Object.dispatch (redux.js?0a4a:222)
    at HandlerRegistryImpl.addTarget (HandlerRegistryImpl.js?0db8:99)
    at registerTarget (registration.js?c129:3)
    at registerHandler (drop.js?169c:50)
``` 

Passing the `dragDropManager` through as a prop allows Mosaic to use the same context:

```js
      <DndContext.Consumer>
				{(ctx) => (
          <Mosaic
            manager={ctx.dragDropManager}
            ...
          />
        )}
```

