### PR TITLE
Get blueprint namespace directly from blueprintjs

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ references:
 jobs:
   build:
     docker:
-      - image: cimg/node
+      - image: circleci/node:dubnium
     working_directory: ~/react-mosaic
     steps:
       - checkout
@@ -31,7 +31,7 @@ jobs:
             - .
   test:
     docker:
-      - image: cimg/node
+      - image: circleci/node:dubnium
     working_directory: ~/react-mosaic
     steps:
       - *attach_workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,9 @@ jobs:
       - image: circleci/node:dubnium
     working_directory: ~/react-mosaic
     steps:
+      - update_certificates:
+          name: Update certificates
+          command: sudo apt-get update && sudo apt-get install -y ca-certificates
       - checkout
       - run:
           name: Install Yarn

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,7 +12,7 @@ jobs:
       - image: circleci/node:dubnium
     working_directory: ~/react-mosaic
     steps:
-      - update_certificates:
+      - run:
           name: Update certificates
           command: sudo apt-get update && sudo apt-get install -y ca-certificates
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ references:
 jobs:
   build:
     docker:
-      - image: circleci/node:dubnium
+      - image: cimg/node:dubnium
     working_directory: ~/react-mosaic
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -9,7 +9,7 @@ references:
 jobs:
   build:
     docker:
-      - image: cimg/node:dubnium
+      - image: cimg/node
     working_directory: ~/react-mosaic
     steps:
       - checkout
@@ -31,7 +31,7 @@ jobs:
             - .
   test:
     docker:
-      - image: circleci/node:dubnium
+      - image: cimg/node
     working_directory: ~/react-mosaic
     steps:
       - *attach_workspace

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,15 +12,7 @@ jobs:
       - image: circleci/node:dubnium
     working_directory: ~/react-mosaic
     steps:
-      - run:
-          name: Update certificates
-          command: sudo apt-get update && sudo apt-get install -y ca-certificates
       - checkout
-      - run:
-          name: Install Yarn
-          command: |
-            curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 1.16.0
-            export PATH="$HOME/.yarn/bin:$PATH"
       - restore_cache:
           keys:
             - *js_deps_cache_key

--- a/src/util/OptionalBlueprint.tsx
+++ b/src/util/OptionalBlueprint.tsx
@@ -1,11 +1,39 @@
-import { Classes } from '@blueprintjs/core';
+import type { Classes } from '@blueprintjs/core';
 import type { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
 import _ from 'lodash';
 import * as React from 'react';
 
+// The fallback in case
+// the module doesn't exist or there is
+// some other error.
+const BLUEPRINT_CLASS_NAMESPACE_FALLBACK = 'bp3';
+
+// Performs a top level import of blueprint and gets the
+// namespace from the Classes export.
+async function getBluePrintClassNamespace() {
+  // Wrap in a try/catch.
+  try
+  {
+    // Import the module.
+    const module = await import("@blueprintjs/core")
+
+    // If we're here, we have the module, get Classes from  it
+    // and get the namespace.
+    return module.Classes.getClassNamespace()
+  }
+  catch (ex) {
+    // Ignore for now.
+  }
+
+  // Return the fallback.
+  return BLUEPRINT_CLASS_NAMESPACE_FALLBACK
+}
+
+// Get the blueprint class namespace.
+const BP_NAMESPACE = await getBluePrintClasses()
+
 export namespace OptionalBlueprint {
-  const BP_NAMESPACE = Classes.getClassNamespace();
   export const Icon = ({
     icon,
     className,

--- a/src/util/OptionalBlueprint.tsx
+++ b/src/util/OptionalBlueprint.tsx
@@ -7,7 +7,7 @@ import * as React from 'react';
 // Performs a top level import of blueprint and gets the classes.
 async function getBluePrintClasses() {
   // The classes.
-  let classes: Classes | undefined
+  let classes
 
   // Wrap in a try/catch.
   try
@@ -27,7 +27,7 @@ async function getBluePrintClasses() {
 }
 
 // Get the classes.
-const BlueprintClasses: Classes | undefined = await getBluePrintClasses()
+const BlueprintClasses = await getBluePrintClasses()
 
 export namespace OptionalBlueprint {
   const BP_NAMESPACE = BlueprintClasses?.getClassNamespace() ?? 'bp3';

--- a/src/util/OptionalBlueprint.tsx
+++ b/src/util/OptionalBlueprint.tsx
@@ -1,36 +1,11 @@
-import type { Classes } from '@blueprintjs/core';
+import { Classes } from '@blueprintjs/core';
 import type { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
 import _ from 'lodash';
 import * as React from 'react';
 
-// Performs a top level import of blueprint and gets the classes.
-async function getBluePrintClasses() {
-  // The classes.
-  let classes
-
-  // Wrap in a try/catch.
-  try
-  {
-    // Import the module.
-    const module = await import("@blueprintjs/core")
-
-    // If we're here, we have the module, get classes from  it.
-    classes = module.Classes
-  }
-  catch (ex) {
-    // Ignore for now.
-  }
-
-  // Return the classes.
-  return classes
-}
-
-// Get the classes.
-const BlueprintClasses = await getBluePrintClasses()
-
 export namespace OptionalBlueprint {
-  const BP_NAMESPACE = BlueprintClasses?.getClassNamespace() ?? 'bp3';
+  const BP_NAMESPACE = Classes.getClassNamespace();
   export const Icon = ({
     icon,
     className,

--- a/src/util/OptionalBlueprint.tsx
+++ b/src/util/OptionalBlueprint.tsx
@@ -31,7 +31,7 @@ async function getBluePrintClassNamespace() {
 }
 
 // Get the blueprint class namespace.
-const BP_NAMESPACE = await getBluePrintClasses()
+const BP_NAMESPACE = await getBluePrintClassNamespace()
 
 export namespace OptionalBlueprint {
   export const Icon = ({

--- a/src/util/OptionalBlueprint.tsx
+++ b/src/util/OptionalBlueprint.tsx
@@ -5,7 +5,7 @@ import _ from 'lodash';
 import * as React from 'react';
 
 export namespace OptionalBlueprint {
-  const BP_NAMESPACE = 'bp3';
+  const BP_NAMESPACE = Classes['getClassNamespace']?.() ?? 'bp3';
   export const Icon = ({
     icon,
     className,

--- a/src/util/OptionalBlueprint.tsx
+++ b/src/util/OptionalBlueprint.tsx
@@ -4,8 +4,33 @@ import classNames from 'classnames';
 import _ from 'lodash';
 import * as React from 'react';
 
+// Performs a top level import of blueprint and gets the classes.
+async function getBluePrintClasses() {
+  // The classes.
+  let classes: Classes | undefined
+
+  // Wrap in a try/catch.
+  try
+  {
+    // Import the module.
+    const module = await import("@blueprintjs/core")
+
+    // If we're here, we have the module, get classes from  it.
+    classes = module.Classes
+  }
+  catch (ex) {
+    // Ignore for now.
+  }
+
+  // Return the classes.
+  return classes
+}
+
+// Get the classes.
+const BlueprintClasses: Classes | undefined = await getBluePrintClasses()
+
 export namespace OptionalBlueprint {
-  const BP_NAMESPACE = Classes['getClassNamespace']?.() ?? 'bp3';
+  const BP_NAMESPACE = BlueprintClasses?.getClassNamespace() ?? 'bp3';
   export const Icon = ({
     icon,
     className,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,17 +8,20 @@
     "jsx": "react",
     "lib": [
       "dom",
-      "scripthost"
+      "es5",
+      "scripthost",
+      "es2015.promise"
     ],
     "noEmit": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "target": "es2020",
+    "target": "es2017",
     "sourceMap": true,
     "strict": true,
-    "module": "es2020"
+    "module": "esnext",
+    "moduleResolution": "node"
   },
   "exclude": [
     "docs",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,7 +17,7 @@
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "target": "es5",
+    "target": "es2017",
     "sourceMap": true,
     "strict": true
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,18 +8,17 @@
     "jsx": "react",
     "lib": [
       "dom",
-      "es5",
-      "scripthost",
-      "es2015.promise"
+      "scripthost"
     ],
     "noEmit": true,
     "noFallthroughCasesInSwitch": true,
     "noImplicitReturns": true,
     "noUnusedLocals": true,
     "noUnusedParameters": true,
-    "target": "es2017",
+    "target": "es2020",
     "sourceMap": true,
-    "strict": true
+    "strict": true,
+    "module": "es2020"
   },
   "exclude": [
     "docs",


### PR DESCRIPTION
#### Fixes #181 

#### Changes proposed in this pull request:

Update `OptionalBlueprint` to set the blueprint namespace constant using a from the `Classes` type exported from blueprint.

Confirmed that it is available in both 3.0 and 4.0:

https://github.com/palantir/blueprint/blob/develop/packages/core/src/common/classes.ts#L316
https://github.com/palantir/blueprint/blob/%40blueprintjs/core%403.54.0/packages/core/src/common/classes.ts#L322

#### Reviewers should focus on:

The buttons being sized correctly in react mosaic when using blueprintjs 4.0 and react mosaic 5.0