### PR TITLE
Add children to the MosaicWindowProps

### DIFF
--- a/src/MosaicWindow.tsx
+++ b/src/MosaicWindow.tsx
@@ -59,7 +59,7 @@ export interface InternalMosaicWindowState {
 }
 
 export class InternalMosaicWindow<T extends MosaicKey> extends React.Component<
-  InternalMosaicWindowProps<T>,
+  InternalMosaicWindowProps<T> & {children?: ReactNode | undefined},
   InternalMosaicWindowState
 > {
   static defaultProps: Partial<InternalMosaicWindowProps<any>> = {

--- a/src/MosaicWindow.tsx
+++ b/src/MosaicWindow.tsx
@@ -37,6 +37,7 @@ export interface MosaicWindowProps<T extends MosaicKey> {
   renderToolbar?: ((props: MosaicWindowProps<T>, draggable: boolean | undefined) => JSX.Element) | null;
   onDragStart?: () => void;
   onDragEnd?: (type: 'drop' | 'reset') => void;
+  children?: React.ReactNode;
 }
 
 export interface InternalDragSourceProps {
@@ -59,7 +60,7 @@ export interface InternalMosaicWindowState {
 }
 
 export class InternalMosaicWindow<T extends MosaicKey> extends React.Component<
-  InternalMosaicWindowProps<T> & {children?: ReactNode | undefined},
+  InternalMosaicWindowProps<T>,
   InternalMosaicWindowState
 > {
   static defaultProps: Partial<InternalMosaicWindowProps<any>> = {


### PR DESCRIPTION
#### Fixes #184 

#### Changes proposed in this pull request:

In React versions lower than 18 there was no need for the `сhildren` property to be in the `MosaicWindowProps`, because the `props` itself was defined in @types/react/index.d.ts as:
```
readonly props: Readonly<P> & Readonly<{ children?: ReactNode | undefined }>;
```

But in React 18 there is no default support for children:
```
readonly props: Readonly<P>;
```

Since a MosaicWindow usually has children, `children?: ReactNode | undefined` should be defined in the `MosaicWindowProps` explicilty. Otherwise using the package with React 18 and trying to add children to a MosaicWindow we get the following error:

```
No overload matches this call.
  Overload 1 of 2, '(props: MosaicWindowProps<string> | Readonly<MosaicWindowProps<string>>): MosaicWindow<string>', gave the following error.
    Type '{ children: Element; path: MosaicBranch[]; title: string; toolbarControls: undefined[]; draggable: true; createNode: () => string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MosaicWindow<string>> & Readonly<MosaicWindowProps<string>>'.
      Property 'children' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MosaicWindow<string>> & Readonly<MosaicWindowProps<string>>'.
  Overload 2 of 2, '(props: MosaicWindowProps<string>, context: any): MosaicWindow<string>', gave the following error.
    Type '{ children: Element; path: MosaicBranch[]; title: string; toolbarControls: undefined[]; draggable: true; createNode: () => string; }' is not assignable to type 'IntrinsicAttributes & IntrinsicClassAttributes<MosaicWindow<string>> & Readonly<MosaicWindowProps<string>>'.
      Property 'children' does not exist on type 'IntrinsicAttributes & IntrinsicClassAttributes<MosaicWindow<string>> & Readonly<MosaicWindowProps<string>>'
```
