### PR TITLE
Import lodash/kebabCase instead of lodash in OptionalBlueprint.tsx

### DIFF
--- a/src/util/OptionalBlueprint.tsx
+++ b/src/util/OptionalBlueprint.tsx
@@ -1,7 +1,7 @@
 import type { Classes } from '@blueprintjs/core';
 import type { IconNames } from '@blueprintjs/icons';
 import classNames from 'classnames';
-import _ from 'lodash';
+import kebabCase from 'lodash/kebabCase';
 import * as React from 'react';
 import { MosaicContext } from '../contextTypes';
 
@@ -28,10 +28,10 @@ export namespace OptionalBlueprint {
   }[keyof typeof Classes];
 
   export function getClasses(blueprintNamespace: string, ...names: BlueprintClass[]): string {
-    return names.map((name) => `${blueprintNamespace}-${_.kebabCase(name)}`).join(' ');
+    return names.map((name) => `${blueprintNamespace}-${kebabCase(name)}`).join(' ');
   }
 
   export function getIconClass(blueprintNamespace: string, iconName: keyof typeof IconNames): string {
-    return `${blueprintNamespace}-icon-${_.kebabCase(iconName)}`;
+    return `${blueprintNamespace}-icon-${kebabCase(iconName)}`;
   }
 }

--- a/tslint.yml
+++ b/tslint.yml
@@ -20,6 +20,7 @@ rules:
       import-sources-order: case-insensitive
       module-source-path: full
       named-imports-order: case-insensitive
+  import-blacklist: [true, "lodash"]
   prettier: true
   no-namespace: false
   variable-name:


### PR DESCRIPTION
#### Fixes #206

#### Changes proposed in this pull request:

- Add the [import-blacklist tslint rule](https://palantir.github.io/tslint/rules/import-blacklist/) to forbid importing `'lodash'`.
- Fix import of `'lodash'` in `OptionalBlueprint.tsx`.

#### Reviewers should focus on:

Not 100% sure the `import-blacklist` tslint rule is wanted. Happy to remove that if we only want the fix in `OptionalBlueprint.tsx`.

#### Screenshot

n.a.