### PR TITLE
add toggleAdditionalOptions action

### DIFF
--- a/README.md
+++ b/README.md
@@ -371,9 +371,10 @@ export interface MosaicWindowActions {
    */
   replaceWithNew: () => Promise<void>;
   /**
-   * Sets the open state for the tray that holds additional controls
+   * Sets the open state for the tray that holds additional controls.
+   * Pass 'toggle' to invert the current state.
    */
-  setAdditionalControlsOpen: (open: boolean) => void;
+  setAdditionalControlsOpen: (open: boolean | 'toggle') => void;
   /**
    * Returns the path to this window
    */

--- a/README.md
+++ b/README.md
@@ -259,6 +259,10 @@ export interface MosaicWindowProps<T extends MosaicKey> {
    */
   onAdditionalControlsToggle?: (toggle: boolean) => void;
   /**
+   * Disables the overlay that blocks interaction with the window when additional controls are open
+   */
+  disableAdditionalControlsOverlay?: boolean;
+  /**
    * Whether or not a user should be able to drag windows around
    */
   draggable?: boolean;

--- a/src/MosaicWindow.tsx
+++ b/src/MosaicWindow.tsx
@@ -33,6 +33,7 @@ export interface MosaicWindowProps<T extends MosaicKey> {
   additionalControls?: React.ReactNode;
   additionalControlButtonText?: string;
   onAdditionalControlsToggle?: (toggle: boolean) => void;
+  closeAdditionalControlsOnClickBody?: boolean;
   draggable?: boolean;
   createNode?: CreateNode<T>;
   renderPreview?: (props: MosaicWindowProps<T>) => JSX.Element;
@@ -98,6 +99,7 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.Component<
       connectDropTarget,
       connectDragPreview,
       draggedMosaicId,
+      closeAdditionalControlsOnClickBody,
     } = this.props;
 
     return (
@@ -112,7 +114,11 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.Component<
           >
             {this.renderToolbar()}
             <div className="mosaic-window-body">{this.props.children}</div>
-            <div className="mosaic-window-body-overlay" onClick={() => this.setAdditionalControlsOpen(false)} />
+            <div className="mosaic-window-body-overlay" onClick={() => {
+              if (closeAdditionalControlsOnClickBody !== false) {
+                this.setAdditionalControlsOpen(false);
+              }
+            }} />
             <div className="mosaic-window-additional-actions-bar">{additionalControls}</div>
             {connectDragPreview(renderPreview!(this.props))}
             <div className="drop-target-container">
@@ -226,6 +232,12 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.Component<
     this.props.onAdditionalControlsToggle?.(additionalControlsOpen);
   };
 
+  private toggleAdditionalControlsOpen = () => {
+    const additionalControlsOpen = !this.state.additionalControlsOpen;
+    this.setState({ additionalControlsOpen });
+    this.props.onAdditionalControlsToggle?.(additionalControlsOpen);
+  };
+
   private getPath = () => this.props.path;
 
   private connectDragSource = (connectedElements: React.ReactElement<any>) => {
@@ -239,6 +251,7 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.Component<
       split: this.split,
       replaceWithNew: this.swap,
       setAdditionalControlsOpen: this.setAdditionalControlsOpen,
+      toggleAdditionalControlsOpen: this.toggleAdditionalControlsOpen,
       getPath: this.getPath,
       connectDragSource: this.connectDragSource,
     },

--- a/src/MosaicWindow.tsx
+++ b/src/MosaicWindow.tsx
@@ -230,13 +230,9 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.Component<
     return Promise.resolve(createNode!(...args)).then((node) => mosaicActions.replaceWith(path, node));
   };
 
-  private setAdditionalControlsOpen = (additionalControlsOpen: boolean) => {
-    this.setState({ additionalControlsOpen });
-    this.props.onAdditionalControlsToggle?.(additionalControlsOpen);
-  };
-
-  private toggleAdditionalControlsOpen = () => {
-    const additionalControlsOpen = !this.state.additionalControlsOpen;
+  private setAdditionalControlsOpen = (additionalControlsOpenOption: boolean | 'toggle') => {
+    const additionalControlsOpen =
+      additionalControlsOpenOption === 'toggle' ? !this.state.additionalControlsOpen : additionalControlsOpenOption;
     this.setState({ additionalControlsOpen });
     this.props.onAdditionalControlsToggle?.(additionalControlsOpen);
   };
@@ -254,7 +250,6 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.Component<
       split: this.split,
       replaceWithNew: this.swap,
       setAdditionalControlsOpen: this.setAdditionalControlsOpen,
-      toggleAdditionalControlsOpen: this.toggleAdditionalControlsOpen,
       getPath: this.getPath,
       connectDragSource: this.connectDragSource,
     },

--- a/src/MosaicWindow.tsx
+++ b/src/MosaicWindow.tsx
@@ -33,7 +33,7 @@ export interface MosaicWindowProps<T extends MosaicKey> {
   additionalControls?: React.ReactNode;
   additionalControlButtonText?: string;
   onAdditionalControlsToggle?: (toggle: boolean) => void;
-  closeAdditionalControlsOnClickBody?: boolean;
+  disableAdditionalControlsOverlay?: boolean;
   draggable?: boolean;
   createNode?: CreateNode<T>;
   renderPreview?: (props: MosaicWindowProps<T>) => JSX.Element;
@@ -99,7 +99,7 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.Component<
       connectDropTarget,
       connectDragPreview,
       draggedMosaicId,
-      closeAdditionalControlsOnClickBody,
+      disableAdditionalControlsOverlay,
     } = this.props;
 
     return (
@@ -114,11 +114,14 @@ export class InternalMosaicWindow<T extends MosaicKey> extends React.Component<
           >
             {this.renderToolbar()}
             <div className="mosaic-window-body">{this.props.children}</div>
-            <div className="mosaic-window-body-overlay" onClick={() => {
-              if (closeAdditionalControlsOnClickBody !== false) {
-                this.setAdditionalControlsOpen(false);
-              }
-            }} />
+            {!disableAdditionalControlsOverlay && (
+              <div
+                className="mosaic-window-body-overlay"
+                onClick={() => {
+                  this.setAdditionalControlsOpen(false);
+                }}
+              />
+            )}
             <div className="mosaic-window-additional-actions-bar">{additionalControls}</div>
             {connectDragPreview(renderPreview!(this.props))}
             <div className="drop-target-container">

--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -76,13 +76,10 @@ export interface MosaicWindowActions {
    */
   replaceWithNew: (...args: any[]) => Promise<void>;
   /**
-   * Sets the open state for the tray that holds additional controls
+   * Sets the open state for the tray that holds additional controls.
+   * Pass 'toggle' to invert the current state.
    */
-  setAdditionalControlsOpen: (open: boolean) => void;
-  /**
-   * Sets the open state for the tray that holds additional controls
-   */
-  toggleAdditionalControlsOpen: () => void;
+  setAdditionalControlsOpen: (open: boolean | 'toggle') => void;
   /**
    * Returns the path to this window
    */

--- a/src/contextTypes.ts
+++ b/src/contextTypes.ts
@@ -80,6 +80,10 @@ export interface MosaicWindowActions {
    */
   setAdditionalControlsOpen: (open: boolean) => void;
   /**
+   * Sets the open state for the tray that holds additional controls
+   */
+  toggleAdditionalControlsOpen: () => void;
+  /**
    * Returns the path to this window
    */
   getPath: () => MosaicPath;


### PR DESCRIPTION
#### Changes proposed in this pull request:
+ Adds an optional boolean prop `closeAdditionalControlsOnClickBody` to disable the default behaviour of closing the additionalControls when clicking anywhere on the body.

+ Introduces a new window context action `toggleAdditionalControlsOpen` to toggle additional controls. `setAdditionalControlsOpen` action required to explicitly pass a boolean and was hard to use as a toggle because the open/close boolean state is internal to the window and not exposed

