### PR TITLE
update Split.calculateRelativePercentage

### DIFF
--- a/src/Split.tsx
+++ b/src/Split.tsx
@@ -122,7 +122,10 @@ export class Split extends React.PureComponent<SplitProps> {
 
   private calculateRelativePercentage(event: MouseEvent | TouchEvent): number {
     const { minimumPaneSizePercentage, direction, boundingBox } = this.props;
-    const parentBBox = this.rootElement.current!.parentElement!.getBoundingClientRect();
+    if (!this.rootElement.current || !this.rootElement.current.parentElement) {
+      return this.props.splitPercentage;
+    }
+    const parentBBox = this.rootElement.current.parentElement.getBoundingClientRect();
     const location = isTouchEvent(event) ? event.changedTouches[0] : event;
 
     let absolutePercentage: number;


### PR DESCRIPTION
Update Split.calculateRelativePercentage to not fail if parentElement no longer exists.

I ran into a typeError when testing resizing views in my application. This solves the problem.

```
TypeError: Cannot read properties of null (reading 'parentElement')
      at Split.Object.<anonymous>.Split.calculateRelativePercentage (../../node_modules/react-mosaic-component/src/Split.tsx:125:50)
```
