### PR TITLE
chore: update uuid to 11.1.1

### DIFF
--- a/libs/react-mosaic-component/package.json
+++ b/libs/react-mosaic-component/package.json
@@ -43,7 +43,7 @@
     "react-dnd-html5-backend": "^16.0.1",
     "react-dnd-multi-backend": "^9.0.0",
     "react-dnd-touch-backend": "^16.0.1",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.1"
   },
   "peerDependencies": {
     "react": "16 - 19"

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "react-dnd-html5-backend": "^16.0.1",
         "react-dnd-multi-backend": "^9.0.0",
         "react-dnd-touch-backend": "^16.0.1",
-        "uuid": "^11.1.0"
+        "uuid": "^11.1.1"
       },
       "devDependencies": {
         "@arethetypeswrong/cli": "0.18.2",
@@ -57,7 +57,6 @@
         "@types/prop-types": "^15.7.5",
         "@types/react": "^19.1.11",
         "@types/react-dom": "^19.1.8",
-        "@types/uuid": "^9.0.0",
         "@vitejs/plugin-react": "^6.0.1",
         "@vitest/coverage-v8": "^4.1.4",
         "@vitest/ui": "^4.1.4",
@@ -11437,13 +11436,6 @@
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
       "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/@types/uuid": {
-      "version": "9.0.8",
-      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-9.0.8.tgz",
-      "integrity": "sha512-jg+97EGIcY9AGHJJRaaPVgetKDsrTgbRjQ5Msgjh/DQKEFl0DtyRr/VCOyD1T2R1MNeWPK/u7JoGhlDZnKBAfA==",
       "dev": true,
       "license": "MIT"
     },
@@ -35361,9 +35353,9 @@
       }
     },
     "node_modules/uuid": {
-      "version": "11.1.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.0.tgz",
-      "integrity": "sha512-0/A9rDy9P7cJ+8w1c9WD9V//9Wj15Ce2MPz8Ri6032usz+NfePxx5AcN3bN+r6ZL6jEo066/yNYB3tn4pQEx+A==",
+      "version": "11.1.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+      "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
       "funding": [
         "https://github.com/sponsors/broofa",
         "https://github.com/sponsors/ctavan"

--- a/package.json
+++ b/package.json
@@ -40,7 +40,7 @@
     "react-dnd-html5-backend": "^16.0.1",
     "react-dnd-multi-backend": "^9.0.0",
     "react-dnd-touch-backend": "^16.0.1",
-    "uuid": "^11.1.0"
+    "uuid": "^11.1.1"
   },
   "devDependencies": {
     "@arethetypeswrong/cli": "0.18.2",
@@ -78,7 +78,6 @@
     "@types/prop-types": "^15.7.5",
     "@types/react": "^19.1.11",
     "@types/react-dom": "^19.1.8",
-    "@types/uuid": "^9.0.0",
     "@vitejs/plugin-react": "^6.0.1",
     "@vitest/coverage-v8": "^4.1.4",
     "@vitest/ui": "^4.1.4",


### PR DESCRIPTION
Closes #245

#### Changes proposed in this pull request:

Updates uuid dependency to 11.1.1.
On master:
```shell
$ npm audit -omit=dev
# npm audit report

uuid  <11.1.1
Severity: moderate
uuid: Missing buffer bounds check in v3/v5/v6 when buf is provided - https://github.com/advisories/GHSA-w5hq-g745-h8pq
fix available via `npm audit fix`
node_modules/uuid

1 moderate severity vulnerability

To address all issues, run:
  npm audit fix
```

On this branch/PR:
```
$ npm audit --omit=dev
found 0 vulnerabilities
```